### PR TITLE
feat:implement createMultiSigAddrwss for P2SH and P2SH-P2WSH

### DIFF
--- a/btc-controller/src/helper/utils/createMultiSigAddress.d.ts
+++ b/btc-controller/src/helper/utils/createMultiSigAddress.d.ts
@@ -1,0 +1,16 @@
+import * as bitcoinjs from "bitcoinjs-lib";
+export type MultiSigAddressType = "P2SH" | "P2SH-P2WSH" | "P2WSH";
+export type MultiSigPublicKey = string | Buffer | Uint8Array;
+export type CreateMultiSigAddressInput = {
+    publicKeys: MultiSigPublicKey[];
+    requiredSignatures: number;
+    network: bitcoinjs.networks.Network;
+    type?: MultiSigAddressType;
+};
+export type CreateMultiSigAddressResult = {
+    type: MultiSigAddressType;
+    address: string;
+    redeemScript?: string;
+    witnessScript?: string;
+};
+export declare function createMultiSigAddress(input: CreateMultiSigAddressInput): CreateMultiSigAddressResult;

--- a/btc-controller/src/helper/utils/createMultiSigAddress.js
+++ b/btc-controller/src/helper/utils/createMultiSigAddress.js
@@ -1,0 +1,85 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.createMultiSigAddress = createMultiSigAddress;
+const bitcoinjs = require("bitcoinjs-lib");
+function toPublicKeyBuffer(publicKey) {
+    if (Buffer.isBuffer(publicKey)) {
+        return publicKey;
+    }
+    if (publicKey instanceof Uint8Array) {
+        return Buffer.from(publicKey);
+    }
+    if (typeof publicKey === "string") {
+        return Buffer.from(publicKey, "hex");
+    }
+    throw new Error("Invalid public key format.");
+}
+function createMultiSigAddress(input) {
+    const { publicKeys, requiredSignatures, network, type = "P2SH" } = input;
+    if (!Array.isArray(publicKeys) || publicKeys.length === 0) {
+        throw new Error("At least one public key is required.");
+    }
+    if (!Number.isInteger(requiredSignatures) || requiredSignatures <= 0) {
+        throw new Error("requiredSignatures must be a positive integer.");
+    }
+    if (requiredSignatures > publicKeys.length) {
+        throw new Error("requiredSignatures cannot be greater than number of public keys.");
+    }
+    const publicKeyBuffers = publicKeys.map(toPublicKeyBuffer);
+    const p2ms = bitcoinjs.payments.p2ms({
+        m: requiredSignatures,
+        pubkeys: publicKeyBuffers,
+        network,
+    });
+    if (!p2ms.output) {
+        throw new Error("Failed to build multisig witness/redeem script.");
+    }
+    if (type === "P2SH") {
+        const p2sh = bitcoinjs.payments.p2sh({
+            redeem: p2ms,
+            network,
+        });
+        if (!p2sh.address) {
+            throw new Error("Failed to generate P2SH multisig address.");
+        }
+        return {
+            type,
+            address: p2sh.address,
+            redeemScript: p2ms.output.toString("hex"),
+        };
+    }
+    if (type === "P2SH-P2WSH") {
+        const p2wsh = bitcoinjs.payments.p2wsh({
+            redeem: p2ms,
+            network,
+        });
+        const p2sh = bitcoinjs.payments.p2sh({
+            redeem: p2wsh,
+            network,
+        });
+        if (!p2sh.address || !p2wsh.output) {
+            throw new Error("Failed to generate P2SH-P2WSH multisig address.");
+        }
+        return {
+            type,
+            address: p2sh.address,
+            redeemScript: p2wsh.output.toString("hex"),
+            witnessScript: p2ms.output.toString("hex"),
+        };
+    }
+    if (type === "P2WSH") {
+        const p2wsh = bitcoinjs.payments.p2wsh({
+            redeem: p2ms,
+            network,
+        });
+        if (!p2wsh.address) {
+            throw new Error("Failed to generate P2WSH multisig address.");
+        }
+        return {
+            type,
+            address: p2wsh.address,
+            witnessScript: p2ms.output.toString("hex"),
+        };
+    }
+    throw new Error("Unsupported multisig address type.");
+}

--- a/btc-controller/src/helper/utils/createMultiSigAddress.ts
+++ b/btc-controller/src/helper/utils/createMultiSigAddress.ts
@@ -1,0 +1,124 @@
+import * as bitcoinjs from "bitcoinjs-lib";
+
+export type MultiSigAddressType = "P2SH" | "P2SH-P2WSH" | "P2WSH";
+
+export type MultiSigPublicKey = string | Buffer | Uint8Array;
+
+export type CreateMultiSigAddressInput = {
+  publicKeys: MultiSigPublicKey[];
+  requiredSignatures: number;
+  network: bitcoinjs.networks.Network;
+  type?: MultiSigAddressType;
+};
+
+export type CreateMultiSigAddressResult = {
+  type: MultiSigAddressType;
+  address: string;
+  redeemScript?: string;
+  witnessScript?: string;
+};
+
+function toPublicKeyBuffer(publicKey: MultiSigPublicKey): Buffer {
+  if (Buffer.isBuffer(publicKey)) {
+    return publicKey;
+  }
+
+  if (publicKey instanceof Uint8Array) {
+    return Buffer.from(publicKey);
+  }
+
+  if (typeof publicKey === "string") {
+    return Buffer.from(publicKey, "hex");
+  }
+
+  throw new Error("Invalid public key format.");
+}
+
+export function createMultiSigAddress(
+  input: CreateMultiSigAddressInput
+): CreateMultiSigAddressResult {
+  const { publicKeys, requiredSignatures, network, type = "P2SH" } = input;
+
+  if (!Array.isArray(publicKeys) || publicKeys.length === 0) {
+    throw new Error("At least one public key is required.");
+  }
+
+  if (!Number.isInteger(requiredSignatures) || requiredSignatures <= 0) {
+    throw new Error("requiredSignatures must be a positive integer.");
+  }
+
+  if (requiredSignatures > publicKeys.length) {
+    throw new Error("requiredSignatures cannot be greater than number of public keys.");
+  }
+
+  const publicKeyBuffers = publicKeys.map(toPublicKeyBuffer);
+
+  const p2ms = bitcoinjs.payments.p2ms({
+    m: requiredSignatures,
+    pubkeys: publicKeyBuffers,
+    network,
+  });
+
+  if (!p2ms.output) {
+    throw new Error("Failed to build multisig witness/redeem script.");
+  }
+
+  if (type === "P2SH") {
+    const p2sh = bitcoinjs.payments.p2sh({
+      redeem: p2ms,
+      network,
+    });
+
+    if (!p2sh.address) {
+      throw new Error("Failed to generate P2SH multisig address.");
+    }
+
+    return {
+      type,
+      address: p2sh.address,
+      redeemScript: p2ms.output.toString("hex"),
+    };
+  }
+
+  if (type === "P2SH-P2WSH") {
+    const p2wsh = bitcoinjs.payments.p2wsh({
+      redeem: p2ms,
+      network,
+    });
+
+    const p2sh = bitcoinjs.payments.p2sh({
+      redeem: p2wsh,
+      network,
+    });
+
+    if (!p2sh.address || !p2wsh.output) {
+      throw new Error("Failed to generate P2SH-P2WSH multisig address.");
+    }
+
+    return {
+      type,
+      address: p2sh.address,
+      redeemScript: p2wsh.output.toString("hex"),
+      witnessScript: p2ms.output.toString("hex"),
+    };
+  }
+
+  if (type === "P2WSH") {
+    const p2wsh = bitcoinjs.payments.p2wsh({
+      redeem: p2ms,
+      network,
+    });
+
+    if (!p2wsh.address) {
+      throw new Error("Failed to generate P2WSH multisig address.");
+    }
+
+    return {
+      type,
+      address: p2wsh.address,
+      witnessScript: p2ms.output.toString("hex"),
+    };
+  }
+
+  throw new Error("Unsupported multisig address type.");
+}

--- a/btc-controller/src/helper/utils/index.d.ts
+++ b/btc-controller/src/helper/utils/index.d.ts
@@ -2,4 +2,5 @@ import { getNetwork } from "./getNetwork";
 import { generateAddress } from "./generateAddress";
 import { calcBip32ExtendedKeys } from "./calcBip32ExtendedKeys";
 import { getAddressFromPk } from "./getAddressFromPk";
-export { getNetwork, generateAddress, calcBip32ExtendedKeys, getAddressFromPk };
+import { createMultiSigAddress } from "./createMultiSigAddress";
+export { getNetwork, generateAddress, calcBip32ExtendedKeys, getAddressFromPk, createMultiSigAddress };

--- a/btc-controller/src/helper/utils/index.js
+++ b/btc-controller/src/helper/utils/index.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.getAddressFromPk = exports.calcBip32ExtendedKeys = exports.generateAddress = exports.getNetwork = void 0;
+exports.createMultiSigAddress = exports.getAddressFromPk = exports.calcBip32ExtendedKeys = exports.generateAddress = exports.getNetwork = void 0;
 const getNetwork_1 = require("./getNetwork");
 Object.defineProperty(exports, "getNetwork", { enumerable: true, get: function () { return getNetwork_1.getNetwork; } });
 const generateAddress_1 = require("./generateAddress");
@@ -9,4 +9,6 @@ const calcBip32ExtendedKeys_1 = require("./calcBip32ExtendedKeys");
 Object.defineProperty(exports, "calcBip32ExtendedKeys", { enumerable: true, get: function () { return calcBip32ExtendedKeys_1.calcBip32ExtendedKeys; } });
 const getAddressFromPk_1 = require("./getAddressFromPk");
 Object.defineProperty(exports, "getAddressFromPk", { enumerable: true, get: function () { return getAddressFromPk_1.getAddressFromPk; } });
+const createMultiSigAddress_1 = require("./createMultiSigAddress");
+Object.defineProperty(exports, "createMultiSigAddress", { enumerable: true, get: function () { return createMultiSigAddress_1.createMultiSigAddress; } });
 //# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiaW5kZXguanMiLCJzb3VyY2VSb290IjoiIiwic291cmNlcyI6WyJpbmRleC50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiOzs7QUFBQSw2Q0FBMEM7QUFLakMsMkZBTEEsdUJBQVUsT0FLQTtBQUpuQix1REFBb0Q7QUFJL0IsZ0dBSlosaUNBQWUsT0FJWTtBQUhwQyxtRUFBZ0U7QUFHMUIsc0dBSDdCLDZDQUFxQixPQUc2QjtBQUYzRCx5REFBc0Q7QUFFTyxpR0FGcEQsbUNBQWdCLE9BRW9EIiwic291cmNlc0NvbnRlbnQiOlsiaW1wb3J0IHsgZ2V0TmV0d29yayB9IGZyb20gXCIuL2dldE5ldHdvcmtcIjtcclxuaW1wb3J0IHsgZ2VuZXJhdGVBZGRyZXNzIH0gZnJvbSBcIi4vZ2VuZXJhdGVBZGRyZXNzXCI7XHJcbmltcG9ydCB7IGNhbGNCaXAzMkV4dGVuZGVkS2V5cyB9IGZyb20gXCIuL2NhbGNCaXAzMkV4dGVuZGVkS2V5c1wiO1xyXG5pbXBvcnQgeyBnZXRBZGRyZXNzRnJvbVBrIH0gZnJvbSBcIi4vZ2V0QWRkcmVzc0Zyb21Qa1wiO1xyXG5cclxuZXhwb3J0IHsgZ2V0TmV0d29yaywgZ2VuZXJhdGVBZGRyZXNzLCBjYWxjQmlwMzJFeHRlbmRlZEtleXMsIGdldEFkZHJlc3NGcm9tUGsgfTtcclxuIl19

--- a/btc-controller/src/helper/utils/index.ts
+++ b/btc-controller/src/helper/utils/index.ts
@@ -2,5 +2,12 @@ import { getNetwork } from "./getNetwork";
 import { generateAddress } from "./generateAddress";
 import { calcBip32ExtendedKeys } from "./calcBip32ExtendedKeys";
 import { getAddressFromPk } from "./getAddressFromPk";
+import { createMultiSigAddress } from "./createMultiSigAddress";
 
-export { getNetwork, generateAddress, calcBip32ExtendedKeys, getAddressFromPk };
+export {
+	getNetwork,
+	generateAddress,
+	calcBip32ExtendedKeys,
+	getAddressFromPk,
+	createMultiSigAddress,
+};

--- a/btc-controller/test/createMultiSigAddress.js
+++ b/btc-controller/test/createMultiSigAddress.js
@@ -60,6 +60,28 @@ describe('createMultiSigAddress', () => {
     assert.ok(result.address.startsWith('2'));
   });
 
+  it('creates a P2WSH (native SegWit) 2-of-3 multisig address', () => {
+    const result = createMultiSigAddress({
+      publicKeys,
+      requiredSignatures: 2,
+      network,
+      type: 'P2WSH',
+    });
+
+    const p2ms = bitcoinjs.payments.p2ms({
+      m: 2,
+      pubkeys: publicKeys.map((k) => Buffer.from(k, 'hex')),
+      network,
+    });
+    const expected = bitcoinjs.payments.p2wsh({ redeem: p2ms, network }).address;
+
+    assert.strictEqual(result.address, expected);
+    assert.strictEqual(result.type, 'P2WSH');
+    assert.strictEqual(result.redeemScript, undefined);
+    assert.ok(result.witnessScript);
+    assert.ok(result.address.startsWith('tb1'));
+  });
+
   it('throws when requiredSignatures is greater than key count', () => {
     assert.throws(() => {
       createMultiSigAddress({

--- a/btc-controller/test/createMultiSigAddress.js
+++ b/btc-controller/test/createMultiSigAddress.js
@@ -1,0 +1,73 @@
+const assert = require('assert');
+const bitcoinjs = require('bitcoinjs-lib');
+const ECPairFactory = require('ecpair').default;
+const ecc = require('@bitcoinerlab/secp256k1');
+const { createMultiSigAddress } = require('../src/helper/utils/createMultiSigAddress');
+
+const ECPair = ECPairFactory(ecc);
+
+function createTestPublicKeys() {
+  const privateKeys = ['01', '02', '03'].map((v) => Buffer.from(v.padStart(64, '0'), 'hex'));
+  return privateKeys.map((pk) => ECPair.fromPrivateKey(pk).publicKey.toString('hex'));
+}
+
+describe('createMultiSigAddress', () => {
+  const network = bitcoinjs.networks.testnet;
+  const publicKeys = createTestPublicKeys();
+
+  it('creates a legacy P2SH 2-of-3 multisig address', () => {
+    const result = createMultiSigAddress({
+      publicKeys,
+      requiredSignatures: 2,
+      network,
+      type: 'P2SH',
+    });
+
+    const p2ms = bitcoinjs.payments.p2ms({
+      m: 2,
+      pubkeys: publicKeys.map((k) => Buffer.from(k, 'hex')),
+      network,
+    });
+    const expected = bitcoinjs.payments.p2sh({ redeem: p2ms, network }).address;
+
+    assert.strictEqual(result.address, expected);
+    assert.strictEqual(result.type, 'P2SH');
+    assert.ok(result.redeemScript);
+    assert.strictEqual(result.witnessScript, undefined);
+    assert.ok(result.address.startsWith('2'));
+  });
+
+  it('creates a nested P2SH-P2WSH 2-of-3 multisig address', () => {
+    const result = createMultiSigAddress({
+      publicKeys,
+      requiredSignatures: 2,
+      network,
+      type: 'P2SH-P2WSH',
+    });
+
+    const p2ms = bitcoinjs.payments.p2ms({
+      m: 2,
+      pubkeys: publicKeys.map((k) => Buffer.from(k, 'hex')),
+      network,
+    });
+    const p2wsh = bitcoinjs.payments.p2wsh({ redeem: p2ms, network });
+    const expected = bitcoinjs.payments.p2sh({ redeem: p2wsh, network }).address;
+
+    assert.strictEqual(result.address, expected);
+    assert.strictEqual(result.type, 'P2SH-P2WSH');
+    assert.ok(result.redeemScript);
+    assert.ok(result.witnessScript);
+    assert.ok(result.address.startsWith('2'));
+  });
+
+  it('throws when requiredSignatures is greater than key count', () => {
+    assert.throws(() => {
+      createMultiSigAddress({
+        publicKeys,
+        requiredSignatures: 4,
+        network,
+        type: 'P2SH',
+      });
+    }, /requiredSignatures cannot be greater than number of public keys/);
+  });
+});


### PR DESCRIPTION
## Multisig Address Support Update

### What Changed
- Implemented `createMultiSigAddress` utility for:
  - Legacy **P2SH**
  - Nested SegWit **P2SH-P2WSH** multisig address generation
- Added input validation for:
  - P2SH
  - P2SH-P2WSH
- Exported the new utility via the helper utils index

### Tests Added
- Unit tests covering:
  - Correct P2SH address generation
  - Correct P2SH-P2WSH address generation
  - Validation failure when required signatures exceed public key count


### Validation
- Ran full `btc-controller` test suite  
- ✅ Result: All tests passing, including new multisig tests