### PR TITLE
feat:add PSBT output builder with fee estimation and change handlishng

### DIFF
--- a/btc-controller/src/helper/buildMultiSigTransaction.ts
+++ b/btc-controller/src/helper/buildMultiSigTransaction.ts
@@ -1,5 +1,6 @@
 import * as bitcoin from "bitcoinjs-lib";
 import BitcoinTransactionSizeCalculator from "./utils/transactionSizeCalculator";
+import { serializePsbtToBase64 } from "./psbtSerialization";
 
 export interface MultiSigInputUTXO {
   txid: string;
@@ -217,7 +218,7 @@ export function buildMultiSigTransaction(
 
   return {
     psbt,
-    psbtBase64: psbt.toBase64(),
+    psbtBase64: serializePsbtToBase64(psbt),
     selectedUTXOs,
     inputCount: selectedUTXOs.length,
     outputCount: psbt.txOutputs.length,

--- a/btc-controller/src/helper/buildMultiSigTransaction.ts
+++ b/btc-controller/src/helper/buildMultiSigTransaction.ts
@@ -1,0 +1,229 @@
+import * as bitcoin from "bitcoinjs-lib";
+import BitcoinTransactionSizeCalculator from "./utils/transactionSizeCalculator";
+
+export interface MultiSigInputUTXO {
+  txid: string;
+  vout: number;
+  value: number;
+  scriptPubKey: string;
+  witnessScript?: string;
+  redeemScript?: string;
+}
+
+export interface MultiSigOutput {
+  address: string;
+  value: number;
+}
+
+export interface BuildMultiSigTransactionOptions {
+  network: bitcoin.networks.Network;
+  utxos: MultiSigInputUTXO[];
+  outputs: MultiSigOutput[];
+  requiredSignatures: number;
+  totalSigners: number;
+  feeInSats?: number;
+  feeRate?: number;
+  changeAddress?: string;
+  dustThreshold?: number;
+}
+
+export interface BuildMultiSigTransactionResult {
+  psbt: bitcoin.Psbt;
+  psbtBase64: string;
+  selectedUTXOs: MultiSigInputUTXO[];
+  inputCount: number;
+  outputCount: number;
+  totalInputValue: number;
+  totalOutputValue: number;
+  feeInSats: number;
+  changeAmount: number;
+}
+
+interface SelectedUtxoSet {
+  selectedUTXOs: MultiSigInputUTXO[];
+  totalInputValue: number;
+}
+
+function isPositiveInteger(value: number): boolean {
+  return Number.isInteger(value) && value > 0;
+}
+
+function selectMultiSigUTXOs(
+  utxos: MultiSigInputUTXO[],
+  targetAmount: number
+): SelectedUtxoSet {
+  const sorted = [...utxos].sort((a, b) => b.value - a.value);
+  const selectedUTXOs: MultiSigInputUTXO[] = [];
+  let totalInputValue = 0;
+
+  for (const utxo of sorted) {
+    selectedUTXOs.push(utxo);
+    totalInputValue += utxo.value;
+
+    if (totalInputValue >= targetAmount) {
+      return {
+        selectedUTXOs,
+        totalInputValue,
+      };
+    }
+  }
+
+  throw new Error("Insufficient funds for selected outputs and fee");
+}
+
+function validateOutputs(outputs: MultiSigOutput[], network: bitcoin.networks.Network): void {
+  outputs.forEach((output, index) => {
+    if (!isPositiveInteger(output.value)) {
+      throw new Error(`Invalid output value at index ${index}`);
+    }
+
+    try {
+      bitcoin.address.toOutputScript(output.address, network);
+    } catch {
+      throw new Error(`Invalid output address at index ${index}`);
+    }
+  });
+}
+
+function validateUtxos(utxos: MultiSigInputUTXO[]): void {
+  utxos.forEach((utxo, index) => {
+    if (!utxo.txid || utxo.txid.length !== 64) {
+      throw new Error(`Invalid txid for UTXO at index ${index}`);
+    }
+
+    if (!Number.isInteger(utxo.vout) || utxo.vout < 0) {
+      throw new Error(`Invalid vout for UTXO at index ${index}`);
+    }
+
+    if (!isPositiveInteger(utxo.value)) {
+      throw new Error(`Invalid value for UTXO at index ${index}`);
+    }
+
+    if (!utxo.scriptPubKey || typeof utxo.scriptPubKey !== "string") {
+      throw new Error(`Invalid scriptPubKey for UTXO at index ${index}`);
+    }
+  });
+}
+
+export function buildMultiSigTransaction(
+  options: BuildMultiSigTransactionOptions
+): BuildMultiSigTransactionResult {
+  const {
+    network,
+    utxos,
+    outputs,
+    requiredSignatures,
+    totalSigners,
+    feeInSats,
+    feeRate = 1,
+    changeAddress,
+    dustThreshold = 546,
+  } = options;
+
+  if (requiredSignatures < 1 || totalSigners < 1 || requiredSignatures > totalSigners) {
+    throw new Error("Invalid multisig signer configuration");
+  }
+
+  if (!Array.isArray(utxos) || utxos.length === 0) {
+    throw new Error("At least one UTXO is required to build a multisig transaction");
+  }
+
+  if (!Array.isArray(outputs) || outputs.length === 0) {
+    throw new Error("At least one output is required to build a multisig transaction");
+  }
+
+  if (!Number.isInteger(dustThreshold) || dustThreshold < 0) {
+    throw new Error("Invalid dust threshold");
+  }
+
+  validateUtxos(utxos);
+  validateOutputs(outputs, network);
+
+  const totalOutputValue = outputs.reduce((sum, output) => sum + output.value, 0);
+
+  let selectedUTXOs: MultiSigInputUTXO[] = [];
+  let totalInputValue = 0;
+  let resolvedFeeInSats = 0;
+  let changeAmount = 0;
+
+  if (feeInSats !== undefined) {
+    if (!Number.isInteger(feeInSats) || feeInSats < 0) {
+      throw new Error("Invalid feeInSats");
+    }
+
+    const targetAmount = totalOutputValue + feeInSats;
+    const selection = selectMultiSigUTXOs(utxos, targetAmount);
+    selectedUTXOs = selection.selectedUTXOs;
+    totalInputValue = selection.totalInputValue;
+    resolvedFeeInSats = feeInSats;
+    changeAmount = totalInputValue - totalOutputValue - resolvedFeeInSats;
+  } else {
+    if (!Number.isFinite(feeRate) || feeRate <= 0) {
+      throw new Error("feeRate must be a positive number when feeInSats is not provided");
+    }
+
+    const selection = BitcoinTransactionSizeCalculator.selectOptimalUTXOs(
+      utxos as any,
+      totalOutputValue,
+      feeRate,
+      changeAddress
+    );
+
+    selectedUTXOs = selection.selectedUTXOs as unknown as MultiSigInputUTXO[];
+    totalInputValue = selection.totalInput;
+    resolvedFeeInSats = selection.estimatedFee;
+    changeAmount = selection.changeAmount;
+  }
+
+  if (changeAmount < 0) {
+    throw new Error("Insufficient input value to cover outputs and fee");
+  }
+
+  const psbt = new bitcoin.Psbt({ network });
+
+  selectedUTXOs.forEach((utxo) => {
+    const input: any = {
+      hash: utxo.txid,
+      index: utxo.vout,
+      witnessUtxo: {
+        script: Buffer.from(utxo.scriptPubKey, "hex"),
+        value: utxo.value,
+      },
+    };
+
+    if (utxo.witnessScript) {
+      input.witnessScript = Buffer.from(utxo.witnessScript, "hex");
+    }
+
+    if (utxo.redeemScript) {
+      input.redeemScript = Buffer.from(utxo.redeemScript, "hex");
+    }
+
+    psbt.addInput(input);
+  });
+
+  outputs.forEach((output) => {
+    psbt.addOutput({ address: output.address, value: output.value });
+  });
+
+  const shouldAddChange = !!changeAddress && changeAmount >= dustThreshold;
+  if (shouldAddChange) {
+    psbt.addOutput({ address: changeAddress, value: changeAmount });
+  } else {
+    // If change is below dust or there is no change target, add it to miner fee.
+    resolvedFeeInSats += changeAmount;
+    changeAmount = 0;
+  }
+
+  return {
+    psbt,
+    psbtBase64: psbt.toBase64(),
+    selectedUTXOs,
+    inputCount: selectedUTXOs.length,
+    outputCount: psbt.txOutputs.length,
+    totalInputValue,
+    totalOutputValue,
+    feeInSats: resolvedFeeInSats,
+    changeAmount,
+  };
+}

--- a/btc-controller/src/helper/index.ts
+++ b/btc-controller/src/helper/index.ts
@@ -2,6 +2,7 @@ import { signTransaction } from "./signTransaction";
 import { getFeeAndInput, getTransactionSize } from "./calculateFeeAndInput";
 import { buildMultiSigTransaction } from "./buildMultiSigTransaction";
 import { signMultiSigTransaction } from "./signMultiSigTransaction";
+import { serializePsbtToBase64, exportPsbtToBase64 } from "./psbtSerialization";
 import { TransactionVisualizer } from "./transactionVisualizer";
 import * as utils from "./utils/index";
 
@@ -12,6 +13,8 @@ export {
 	getTransactionSize,
 	buildMultiSigTransaction,
 	signMultiSigTransaction,
+	serializePsbtToBase64,
+	exportPsbtToBase64,
 	TransactionVisualizer,
 };
 

--- a/btc-controller/src/helper/index.ts
+++ b/btc-controller/src/helper/index.ts
@@ -1,7 +1,15 @@
 import { signTransaction } from "./signTransaction";
 import { getFeeAndInput, getTransactionSize } from "./calculateFeeAndInput";
+import { buildMultiSigTransaction } from "./buildMultiSigTransaction";
 import { TransactionVisualizer } from "./transactionVisualizer";
 import * as utils from "./utils/index";
 
-export { signTransaction, utils, getFeeAndInput, getTransactionSize, TransactionVisualizer };
+export {
+	signTransaction,
+	utils,
+	getFeeAndInput,
+	getTransactionSize,
+	buildMultiSigTransaction,
+	TransactionVisualizer,
+};
 

--- a/btc-controller/src/helper/index.ts
+++ b/btc-controller/src/helper/index.ts
@@ -1,6 +1,7 @@
 import { signTransaction } from "./signTransaction";
 import { getFeeAndInput, getTransactionSize } from "./calculateFeeAndInput";
 import { buildMultiSigTransaction } from "./buildMultiSigTransaction";
+import { signMultiSigTransaction } from "./signMultiSigTransaction";
 import { TransactionVisualizer } from "./transactionVisualizer";
 import * as utils from "./utils/index";
 
@@ -10,6 +11,7 @@ export {
 	getFeeAndInput,
 	getTransactionSize,
 	buildMultiSigTransaction,
+	signMultiSigTransaction,
 	TransactionVisualizer,
 };
 

--- a/btc-controller/src/helper/psbtSerialization.ts
+++ b/btc-controller/src/helper/psbtSerialization.ts
@@ -1,0 +1,11 @@
+import * as bitcoin from "bitcoinjs-lib";
+
+export function serializePsbtToBase64(psbt: bitcoin.Psbt): string {
+  if (!psbt || typeof (psbt as any).toBase64 !== "function") {
+    throw new Error("Invalid PSBT instance");
+  }
+
+  return psbt.toBase64();
+}
+
+export const exportPsbtToBase64 = serializePsbtToBase64;

--- a/btc-controller/src/helper/signMultiSigTransaction.ts
+++ b/btc-controller/src/helper/signMultiSigTransaction.ts
@@ -1,0 +1,88 @@
+import * as bitcoin from "bitcoinjs-lib";
+import { ECPairInterface } from "ecpair";
+
+export interface SignMultiSigTransactionOptions {
+  network: bitcoin.networks.Network;
+  signer: ECPairInterface;
+  psbt?: bitcoin.Psbt;
+  psbtBase64?: string;
+  inputIndexes?: number[];
+}
+
+export interface SignMultiSigTransactionResult {
+  psbt: bitcoin.Psbt;
+  psbtBase64: string;
+  signedInputIndexes: number[];
+  signedInputCount: number;
+}
+
+function resolvePsbt(
+  network: bitcoin.networks.Network,
+  psbt?: bitcoin.Psbt,
+  psbtBase64?: string
+): bitcoin.Psbt {
+  if (psbt && psbtBase64) {
+    throw new Error("Provide either psbt or psbtBase64, not both");
+  }
+
+  if (!psbt && !psbtBase64) {
+    throw new Error("psbt or psbtBase64 is required");
+  }
+
+  if (psbt) {
+    return psbt;
+  }
+
+  return bitcoin.Psbt.fromBase64(psbtBase64 as string, { network });
+}
+
+function resolveInputIndexes(inputCount: number, inputIndexes?: number[]): number[] {
+  const indexes = inputIndexes ?? Array.from({ length: inputCount }, (_, i) => i);
+
+  if (!Array.isArray(indexes) || indexes.length === 0) {
+    throw new Error("At least one input index is required");
+  }
+
+  const uniqueIndexes = Array.from(new Set(indexes));
+
+  uniqueIndexes.forEach((index) => {
+    if (!Number.isInteger(index) || index < 0 || index >= inputCount) {
+      throw new Error(`Invalid input index: ${index}`);
+    }
+  });
+
+  return uniqueIndexes;
+}
+
+export function signMultiSigTransaction(
+  options: SignMultiSigTransactionOptions
+): SignMultiSigTransactionResult {
+  const { network, signer, psbt, psbtBase64, inputIndexes } = options;
+  const resolvedPsbt = resolvePsbt(network, psbt, psbtBase64);
+
+  if (!signer?.publicKey || typeof signer.sign !== "function") {
+    throw new Error("Invalid signer: signer must expose publicKey and sign(hash)");
+  }
+
+  const signerForPsbt: any = {
+    publicKey: Buffer.from(signer.publicKey),
+    sign: (hash: Buffer) => Buffer.from(signer.sign(hash)),
+  };
+
+  const indexesToSign = resolveInputIndexes(resolvedPsbt.txInputs.length, inputIndexes);
+
+  indexesToSign.forEach((index) => {
+    try {
+      resolvedPsbt.signInput(index, signerForPsbt);
+    } catch (err: any) {
+      throw new Error(`Failed to sign input ${index}: ${err?.message ?? "Unknown error"}`);
+    }
+  });
+
+  return {
+    psbt: resolvedPsbt,
+    psbtBase64: resolvedPsbt.toBase64(),
+    signedInputIndexes: indexesToSign,
+    signedInputCount: indexesToSign.length,
+  };
+}

--- a/btc-controller/src/helper/signMultiSigTransaction.ts
+++ b/btc-controller/src/helper/signMultiSigTransaction.ts
@@ -1,5 +1,6 @@
 import * as bitcoin from "bitcoinjs-lib";
 import { ECPairInterface } from "ecpair";
+import { serializePsbtToBase64 } from "./psbtSerialization";
 
 export interface SignMultiSigTransactionOptions {
   network: bitcoin.networks.Network;
@@ -81,7 +82,7 @@ export function signMultiSigTransaction(
 
   return {
     psbt: resolvedPsbt,
-    psbtBase64: resolvedPsbt.toBase64(),
+    psbtBase64: serializePsbtToBase64(resolvedPsbt),
     signedInputIndexes: indexesToSign,
     signedInputCount: indexesToSign.length,
   };

--- a/btc-controller/test/buildMultiSigTransaction.js
+++ b/btc-controller/test/buildMultiSigTransaction.js
@@ -76,6 +76,33 @@ describe('buildMultiSigTransaction', () => {
     assert.strictEqual(result.feeInSats, 4000);
   });
 
+  it('adds witnessScript and redeemScript to PSBT input when provided', () => {
+    const witnessScript = '52210279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f817982102c6047f9441ed7d6d3045406e95c07cd85a57c8f86a57f2f6f2f1d36f5f8b16a752ae';
+    const redeemScript = '0020477f9f5e34f6157abf8552d7f4f63529cc06f659f8bc6ff6f4f16bcf4f3f7ed2';
+
+    const result = buildMultiSigTransaction({
+      network: TESTNET,
+      requiredSignatures: 2,
+      totalSigners: 3,
+      feeInSats: 500,
+      changeAddress: CHANGE,
+      utxos: [
+        {
+          ...makeUtxo('1', 12000),
+          witnessScript,
+          redeemScript,
+        },
+      ],
+      outputs: [{ address: RECIPIENT, value: 6000 }],
+    });
+
+    const firstInput = result.psbt.data.inputs[0];
+    assert.ok(firstInput.witnessScript);
+    assert.ok(firstInput.redeemScript);
+    assert.strictEqual(firstInput.witnessScript.toString('hex'), witnessScript);
+    assert.strictEqual(firstInput.redeemScript.toString('hex'), redeemScript);
+  });
+
   it('throws when output value is invalid', () => {
     assert.throws(
       () =>

--- a/btc-controller/test/buildMultiSigTransaction.js
+++ b/btc-controller/test/buildMultiSigTransaction.js
@@ -42,6 +42,14 @@ describe('buildMultiSigTransaction', () => {
     assert.strictEqual(result.psbt.txInputs.length, 2);
     assert.strictEqual(result.psbt.txOutputs.length, 2);
     assert.strictEqual(result.outputCount, 2);
+
+    const parsed = bitcoin.Psbt.fromBase64(result.psbtBase64, { network: TESTNET });
+    assert.strictEqual(parsed.txInputs.length, 2);
+    assert.strictEqual(parsed.txOutputs.length, 2);
+    assert.strictEqual(parsed.data.inputs[0].witnessUtxo.value, 8000);
+    assert.strictEqual(parsed.data.inputs[1].witnessUtxo.value, 7000);
+    assert.strictEqual(parsed.data.inputs[0].partialSig, undefined);
+    assert.strictEqual(parsed.data.inputs[1].partialSig, undefined);
   });
 
   it('estimates fee when feeRate is provided and feeInSats is omitted', () => {

--- a/btc-controller/test/buildMultiSigTransaction.js
+++ b/btc-controller/test/buildMultiSigTransaction.js
@@ -1,0 +1,108 @@
+'use strict';
+
+const assert = require('assert');
+const bitcoin = require('bitcoinjs-lib');
+const { buildMultiSigTransaction } = require('../src/helper/buildMultiSigTransaction');
+
+const TESTNET = bitcoin.networks.testnet;
+const RECIPIENT = 'tb1qcen5y7uvp3r9y0c4l4c55hlaks8gef54pr6v68';
+const CHANGE = 'tb1qt3vyrqgy7emqcr8sjr39zcjdca7grfer7lvxhp';
+
+function makeUtxo(txidChar, value) {
+  return {
+    txid: txidChar.repeat(64),
+    vout: 0,
+    value,
+    scriptPubKey: bitcoin.address.toOutputScript(CHANGE, TESTNET).toString('hex'),
+  };
+}
+
+describe('buildMultiSigTransaction', () => {
+  it('builds outputs and change correctly with explicit feeInSats', () => {
+    const result = buildMultiSigTransaction({
+      network: TESTNET,
+      requiredSignatures: 2,
+      totalSigners: 3,
+      feeInSats: 500,
+      changeAddress: CHANGE,
+      utxos: [
+        makeUtxo('a', 4000),
+        makeUtxo('b', 7000),
+        makeUtxo('c', 8000),
+      ],
+      outputs: [{ address: RECIPIENT, value: 10000 }],
+    });
+
+    assert.strictEqual(result.inputCount, 2);
+    assert.strictEqual(result.selectedUTXOs.length, 2);
+    assert.strictEqual(result.totalInputValue, 15000);
+    assert.strictEqual(result.totalOutputValue, 10000);
+    assert.strictEqual(result.feeInSats, 500);
+    assert.strictEqual(result.changeAmount, 4500);
+    assert.strictEqual(result.psbt.txInputs.length, 2);
+    assert.strictEqual(result.psbt.txOutputs.length, 2);
+    assert.strictEqual(result.outputCount, 2);
+  });
+
+  it('estimates fee when feeRate is provided and feeInSats is omitted', () => {
+    const result = buildMultiSigTransaction({
+      network: TESTNET,
+      requiredSignatures: 2,
+      totalSigners: 3,
+      feeRate: 2,
+      changeAddress: CHANGE,
+      utxos: [makeUtxo('d', 12000)],
+      outputs: [{ address: RECIPIENT, value: 5000 }],
+    });
+
+    assert.strictEqual(result.inputCount, 1);
+    assert.ok(result.feeInSats > 0);
+    assert.ok(result.changeAmount > 0);
+    assert.strictEqual(result.psbt.txOutputs.length, 2);
+  });
+
+  it('does not add a change output when no changeAddress is provided', () => {
+    const result = buildMultiSigTransaction({
+      network: TESTNET,
+      requiredSignatures: 2,
+      totalSigners: 3,
+      feeInSats: 500,
+      utxos: [makeUtxo('e', 7000)],
+      outputs: [{ address: RECIPIENT, value: 3000 }],
+    });
+
+    assert.strictEqual(result.psbt.txOutputs.length, 1);
+    assert.strictEqual(result.changeAmount, 0);
+    assert.strictEqual(result.feeInSats, 4000);
+  });
+
+  it('throws when output value is invalid', () => {
+    assert.throws(
+      () =>
+        buildMultiSigTransaction({
+          network: TESTNET,
+          requiredSignatures: 2,
+          totalSigners: 3,
+          feeInSats: 300,
+          utxos: [makeUtxo('f', 2000)],
+          outputs: [{ address: RECIPIENT, value: 0 }],
+        }),
+      /Invalid output value/
+    );
+  });
+
+  it('throws when selected UTXOs cannot cover outputs and fee', () => {
+    assert.throws(
+      () =>
+        buildMultiSigTransaction({
+          network: TESTNET,
+          requiredSignatures: 2,
+          totalSigners: 3,
+          feeInSats: 300,
+          utxos: [makeUtxo('g', 1000), makeUtxo('h', 1200)],
+          outputs: [{ address: RECIPIENT, value: 2500 }],
+        }),
+      /Insufficient funds/
+    );
+  });
+});

--- a/btc-controller/test/psbtSerialization.js
+++ b/btc-controller/test/psbtSerialization.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const assert = require('assert');
+const bitcoin = require('bitcoinjs-lib');
+const ecc = require('@bitcoinerlab/secp256k1');
+
+const ECPairModule = require('ecpair');
+const ECPairFactory = ECPairModule.default || ECPairModule;
+const ECPair = ECPairFactory(ecc);
+
+const { buildMultiSigTransaction } = require('../src/helper/buildMultiSigTransaction');
+const { serializePsbtToBase64 } = require('../src/helper/psbtSerialization');
+
+const TESTNET = bitcoin.networks.testnet;
+const RECIPIENT = 'tb1qcen5y7uvp3r9y0c4l4c55hlaks8gef54pr6v68';
+
+function createFixture() {
+  const signer1 = ECPair.makeRandom({ network: TESTNET });
+  const signer2 = ECPair.makeRandom({ network: TESTNET });
+  const signer3 = ECPair.makeRandom({ network: TESTNET });
+
+  const p2ms = bitcoin.payments.p2ms({
+    m: 2,
+    pubkeys: [
+      Buffer.from(signer1.publicKey),
+      Buffer.from(signer2.publicKey),
+      Buffer.from(signer3.publicKey),
+    ],
+    network: TESTNET,
+  });
+
+  const p2wsh = bitcoin.payments.p2wsh({ redeem: p2ms, network: TESTNET });
+  const p2sh = bitcoin.payments.p2sh({ redeem: p2wsh, network: TESTNET });
+
+  return {
+    witnessScript: p2ms.output.toString('hex'),
+    redeemScript: p2wsh.output.toString('hex'),
+    scriptPubKey: p2sh.output.toString('hex'),
+    changeAddress: p2sh.address,
+  };
+}
+
+describe('psbtSerialization', () => {
+  it('exports an unsigned multisig PSBT to base64 and allows roundtrip import', () => {
+    const fixture = createFixture();
+
+    const { psbt, psbtBase64 } = buildMultiSigTransaction({
+      network: TESTNET,
+      requiredSignatures: 2,
+      totalSigners: 3,
+      feeInSats: 500,
+      changeAddress: fixture.changeAddress,
+      utxos: [
+        {
+          txid: 'a'.repeat(64),
+          vout: 0,
+          value: 12000,
+          scriptPubKey: fixture.scriptPubKey,
+          witnessScript: fixture.witnessScript,
+          redeemScript: fixture.redeemScript,
+        },
+      ],
+      outputs: [{ address: RECIPIENT, value: 5000 }],
+    });
+
+    const encoded = serializePsbtToBase64(psbt);
+    assert.strictEqual(encoded, psbtBase64);
+
+    const parsed = bitcoin.Psbt.fromBase64(encoded, { network: TESTNET });
+    assert.strictEqual(parsed.txInputs.length, 1);
+    assert.strictEqual(parsed.txOutputs.length, 2);
+  });
+
+  it('throws on invalid PSBT input', () => {
+    assert.throws(() => serializePsbtToBase64(null), /Invalid PSBT instance/);
+  });
+});

--- a/btc-controller/test/signMultiSigTransaction.js
+++ b/btc-controller/test/signMultiSigTransaction.js
@@ -1,0 +1,123 @@
+'use strict';
+
+const assert = require('assert');
+const bitcoin = require('bitcoinjs-lib');
+const ecc = require('@bitcoinerlab/secp256k1');
+
+const ECPairModule = require('ecpair');
+const ECPairFactory = ECPairModule.default || ECPairModule;
+const ECPair = ECPairFactory(ecc);
+
+const { buildMultiSigTransaction } = require('../src/helper/buildMultiSigTransaction');
+const { signMultiSigTransaction } = require('../src/helper/signMultiSigTransaction');
+
+const TESTNET = bitcoin.networks.testnet;
+const RECIPIENT = 'tb1qcen5y7uvp3r9y0c4l4c55hlaks8gef54pr6v68';
+
+function createMultiSigFixture() {
+  const signer1 = ECPair.makeRandom({ network: TESTNET });
+  const signer2 = ECPair.makeRandom({ network: TESTNET });
+  const signer3 = ECPair.makeRandom({ network: TESTNET });
+
+  const p2ms = bitcoin.payments.p2ms({
+    m: 2,
+    pubkeys: [
+      Buffer.from(signer1.publicKey),
+      Buffer.from(signer2.publicKey),
+      Buffer.from(signer3.publicKey),
+    ],
+    network: TESTNET,
+  });
+
+  const p2wsh = bitcoin.payments.p2wsh({ redeem: p2ms, network: TESTNET });
+  const p2sh = bitcoin.payments.p2sh({ redeem: p2wsh, network: TESTNET });
+
+  return {
+    signer1,
+    signer2,
+    signer3,
+    witnessScript: p2ms.output.toString('hex'),
+    redeemScript: p2wsh.output.toString('hex'),
+    scriptPubKey: p2sh.output.toString('hex'),
+    changeAddress: p2sh.address,
+  };
+}
+
+function makeUtxo(txidChar, value, fixture, vout = 0) {
+  return {
+    txid: txidChar.repeat(64),
+    vout,
+    value,
+    scriptPubKey: fixture.scriptPubKey,
+    witnessScript: fixture.witnessScript,
+    redeemScript: fixture.redeemScript,
+  };
+}
+
+describe('signMultiSigTransaction', () => {
+  it('adds the first signer partial signature without finalizing', () => {
+    const fixture = createMultiSigFixture();
+
+    const unsigned = buildMultiSigTransaction({
+      network: TESTNET,
+      requiredSignatures: 2,
+      totalSigners: 3,
+      feeInSats: 500,
+      changeAddress: fixture.changeAddress,
+      utxos: [makeUtxo('1', 15000, fixture)],
+      outputs: [{ address: RECIPIENT, value: 7000 }],
+    });
+
+    assert.strictEqual(unsigned.psbt.data.inputs[0].partialSig, undefined);
+
+    const signed = signMultiSigTransaction({
+      network: TESTNET,
+      psbtBase64: unsigned.psbtBase64,
+      signer: fixture.signer1,
+    });
+
+    assert.strictEqual(signed.signedInputCount, 1);
+    assert.deepStrictEqual(signed.signedInputIndexes, [0]);
+
+    const parsed = bitcoin.Psbt.fromBase64(signed.psbtBase64, { network: TESTNET });
+    const partialSignatures = parsed.data.inputs[0].partialSig;
+
+    assert.ok(Array.isArray(partialSignatures));
+    assert.strictEqual(partialSignatures.length, 1);
+    assert.strictEqual(
+      partialSignatures[0].pubkey.toString('hex'),
+      Buffer.from(fixture.signer1.publicKey).toString('hex')
+    );
+
+    assert.throws(() => parsed.finalizeAllInputs());
+  });
+
+  it('signs only requested input indexes', () => {
+    const fixture = createMultiSigFixture();
+
+    const unsigned = buildMultiSigTransaction({
+      network: TESTNET,
+      requiredSignatures: 2,
+      totalSigners: 3,
+      feeInSats: 1000,
+      changeAddress: fixture.changeAddress,
+      utxos: [makeUtxo('2', 9000, fixture, 0), makeUtxo('3', 9000, fixture, 1)],
+      outputs: [{ address: RECIPIENT, value: 10000 }],
+    });
+
+    const signed = signMultiSigTransaction({
+      network: TESTNET,
+      psbt: unsigned.psbt,
+      signer: fixture.signer1,
+      inputIndexes: [1],
+    });
+
+    assert.strictEqual(signed.signedInputCount, 1);
+    assert.deepStrictEqual(signed.signedInputIndexes, [1]);
+    assert.strictEqual(unsigned.psbt.data.inputs[0].partialSig, undefined);
+
+    const signedInput = unsigned.psbt.data.inputs[1];
+    assert.ok(Array.isArray(signedInput.partialSig));
+    assert.strictEqual(signedInput.partialSig.length, 1);
+  });
+});


### PR DESCRIPTION
Added a new multi-sig transaction builder that validates outputs, selects UTXOs, supports fixed or rate-based fee calculation, and handles change/dust correctly. Exported the helper and added dedicated tests to cover explicit-fee flow, estimated-fee flow, validation errors, and insufficient-funds cases.