### PR TITLE
fix(ui): truncate txid and add block explorer link in transaction list

### DIFF
--- a/wallet-ui/app.js
+++ b/wallet-ui/app.js
@@ -202,10 +202,14 @@ function renderTransactions(txs) {
       ? new Date(tx.blockTime * 1000).toLocaleDateString()
       : 'Pending';
 
+    const explorerBase = state.network === 'TESTNET'
+      ? 'https://mempool.space/testnet/tx/'
+      : 'https://mempool.space/tx/';
+
     return `
       <div class="tx-item">
         <div class="tx-info">
-          <div class="tx-id">${tx.txid}</div>
+          <div class="tx-id"><a href="${explorerBase}${tx.txid}" target="_blank" rel="noopener noreferrer">${tx.txid.slice(0, 8)}...${tx.txid.slice(-8)}</a></div>
           <div class="tx-time">${timeStr}</div>
         </div>
         <div>

--- a/wallet-ui/style.css
+++ b/wallet-ui/style.css
@@ -454,6 +454,17 @@ textarea { resize: vertical; }
   max-width: 200px;
 }
 
+.tx-id a {
+  color: var(--accent);
+  text-decoration: none;
+  transition: color 0.2s;
+}
+
+.tx-id a:hover {
+  color: var(--accent-hover);
+  text-decoration: underline;
+}
+
 .tx-time {
   font-size: 11px;
   color: var(--text-muted);


### PR DESCRIPTION
- Truncate 64-char txid to first 8 + last 8 characters for readability
- Wrap txid in a clickable link to mempool.space block explorer
- Respect network selection (testnet vs mainnet) for explorer URL
- Add hover styling for the transaction ID links